### PR TITLE
Modified release history with latest version 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ plato: {
 
 ## Release History
 
+ - 0.2.1 bumped for plato 0.6.0
  - 0.2.0 bumped for plato 0.5.0
  - 0.1.5 updating deps for grunt 0.4.0 final
  - 0.1.4 defaulting to new maintainability index


### PR DESCRIPTION
Just a silly update, added version 0.2.1 to the Release History in order to keep it updated.
