### PR TITLE
Remove trailing commas from doc examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ plato: {
       }
     },
     files: {
-      'reports': ['src/**/*.js'],
+      'reports': ['src/**/*.js']
     }
   }
 }
@@ -98,7 +98,7 @@ plato: {
       jshint : grunt.file.readJSON('.jshintrc')
     },
     files: {
-      'reports': ['src/**/*.js'],
+      'reports': ['src/**/*.js']
     }
   }
 }
@@ -113,7 +113,7 @@ plato: {
       jshint : false
     },
     files: {
-      'reports': ['src/**/*.js'],
+      'reports': ['src/**/*.js']
     }
   }
 }
@@ -128,7 +128,7 @@ plato: {
       exclude: /\.min\.js$/    // excludes source files finishing with ".min.js"
     },
     files: {
-      'reports': ['src/**/*.js'],
+      'reports': ['src/**/*.js']
     }
   }
 }


### PR DESCRIPTION
I'm a little unsure if this is intended or not, but there are a whole lot of unneeded trailing commas in the documentation examples. This puzzled me quite a bit when reading the docs as it gave me the feeling as if there's something missing.

Maybe this is a personal style choice, but in case not feel free to merge this.
