### PR TITLE
Bumped plato version to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-plato",
   "description": "Generate complexity analysis reports with plato",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "homepage": "https://github.com/jsoverson/grunt-plato",
   "author": {
     "name": "Jarrod Overson",
@@ -13,6 +13,11 @@
       "name": "Sergio Ruiz",
       "email": "serginator@gmail.com",
       "url": "http://www.serginator.com/"
+    },
+    {
+      "name": "Derek Yeager",
+      "email": "dcy2003@gmail.com",
+      "url": "https://github.com/dcy2003"
     }
   ],
   "repository": {
@@ -50,6 +55,6 @@
     "analysis"
   ],
   "dependencies": {
-    "plato": "~1.2.0"
+    "plato": "~1.3.0"
   }
 }


### PR DESCRIPTION
Plato 1.3.0 includes a fix for the issue in which multiple "could not parse JSON" issues are reported upon first run.